### PR TITLE
Apply image format config across scripts

### DIFF
--- a/config/example_config.toml
+++ b/config/example_config.toml
@@ -29,6 +29,7 @@ input_video_path = "sample_data/"
 output_directory = "output/" # Output directory for the processed video for visualization. Only works if visualization is enabled.
 frame_interval = 50
 batch_size = 2
+image_format = "jpg"
 
 [visualization]
 enabled = true

--- a/config/heavy_mode.toml
+++ b/config/heavy_mode.toml
@@ -31,6 +31,7 @@ default_mode = "list | detect | segment | describe | extract_scene | extract_obj
 input_video_path = "sample_data/"
 output_directory = "output/" # Output directory for the processed video for visualization. Only works if visualization is enabled.
 frame_interval = 30
+image_format = "jpg"
 
 [visualization]
 enabled = true

--- a/config/light_mode.toml
+++ b/config/light_mode.toml
@@ -29,6 +29,7 @@ default_mode = "list detect segment describe extract_features"
 input_video_path = "sample_data/"
 output_directory = "output/"
 frame_interval = 100
+image_format = "jpg"
 
 [visualization]
 enabled = false

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,7 +22,7 @@ Many scripts in this folder share common conventions and command-line arguments.
 ### Common Command-Line Arguments
 
 *   `--config <path_to_config.toml>`: Specifies the path to a configuration file (e.g., `config/heavy_mode.toml`). This file likely contains settings for models used in tasks like object detection, segmentation, or listing.
-*   `--min-images <number>`: Used by scripts that process video folders (subfolders with sequences of images). This argument sets the minimum number of JPEG images a subfolder must contain to be processed. The default is typically 5.
+*   `--min-images <number>`: Used by scripts that process video folders (subfolders with sequences of images). This argument sets the minimum number of images (matching the configured format) a subfolder must contain to be processed. The default is typically 5.
 *   `--folder <path_to_root_folder>`: Specifies the root directory that contains subfolders of images to be processed.
 *   `--source-dir <path_to_source>`: Specifies the input directory for scripts like depth estimation. This directory can contain raw image files or ZIP archives of images.
 *   `--target-dir <path_to_target>`: Specifies the output directory where results (like extracted images from ZIPs and generated depth maps) will be stored.
@@ -43,7 +43,7 @@ Several scripts leverage `batch_processor.py` to efficiently process large numbe
 
 - `--folder` (required): Root folder containing video subfolders with images
 - `--config` (optional): Path to configuration file (default: `config/heavy_mode.toml`)
-- `--min-images` (optional): Minimum number of JPEG images required per subfolder (default: 5)
+- `--min-images` (optional): Minimum number of images (matching the configured format) required per subfolder (default: 5)
 - `--categories` (optional): JSON string defining tag categories. This allows for customized, structured tagging instead of a simple keyword list.
 
 #### Usage Examples
@@ -119,11 +119,11 @@ dataset/
 
 * `--folder <path>`: (Required) Root directory containing subfolders of images (e.g., individual video clips). Each subfolder is processed independently.
 * `--config <path>`: (Optional) Path to the configuration file specifying the captioning model. Defaults to `config/heavy_mode.toml`.
-* `--min-images <number>`: (Optional) Minimum number of JPEG images a subfolder must contain to be processed. Defaults to `5`.
+* `--min-images <number>`: (Optional) Minimum number of images (matching the configured format) a subfolder must contain to be processed. Defaults to `5`.
 
 #### Input
 
-* JPEG images stored in subfolders of the specified `--folder` directory.
+* Images (with the configured format) stored in subfolders of the specified `--folder` directory.
 
 #### Output
 
@@ -166,7 +166,7 @@ my_clips/
 
 - `--folder` (required): Root folder containing video subfolders with tagged images
 - `--config` (optional): Path to configuration file (default: `config/heavy_mode.toml`)
-- `--min-images` (optional): Minimum number of JPEG images required per subfolder (default: 5)
+- `--min-images` (optional): Minimum number of images (matching the configured format) required per subfolder (default: 5)
 - `--extra-tags-file` (optional): JSON file containing tags that will be merged with those from Stage 1 before detection. Defaults to `config/default_extra_tags.json`.
 
 #### Usage Examples
@@ -258,7 +258,7 @@ python scripts/batch_depth_estimation.py --folder /path/to/dataset --recursive -
 
 #### Input
 
-Supports JPG, JPEG, and PNG image formats:
+Supports images in the configured format (JPG by default):
 
 ```
 dataset/
@@ -312,8 +312,8 @@ The `batch_processor.py` script provides a generic framework for processing imag
 *   **Custom Functions**: Accepts custom `inference_func` (to perform the main processing task like depth estimation or tagging) and `save_func` (to store the results).
 *   **Memory Management**: Includes mechanisms to clear the image buffer and invoke garbage collection, which is important when dealing with many high-resolution images.
 *   **Image Collection Utilities**:
-    *   `collect_images(folder)`: Collects all JPG/JPEG images from a given folder (non-recursive).
-    *   `collect_images_recursive(root_dir)`: Collects all JPG/JPEG images recursively from a root directory and its subdirectories.
+    *   `collect_images(folder)`: Collects all images matching the configured format from a given folder (non-recursive).
+    *   `collect_images_recursive(root_dir)`: Collects all images matching the configured format recursively from a root directory and its subdirectories.
 
 **Usage**:
 

--- a/scripts/batch_processor.py
+++ b/scripts/batch_processor.py
@@ -95,32 +95,45 @@ class BatchProcessor:
         """Return number of loaded images."""
         return len(self.path_to_image)
 
-def collect_images(folder: Path) -> List[Path]:
-    """Collect JPG/JPEG/PNG images from a folder.
+def collect_images(folder: Path, image_format: str = "jpg") -> List[Path]:
+    """Collect images of a specific format from a folder.
 
     Args:
-        folder: Folder to search for images
+        folder: Folder to search for images.
+        image_format: Desired image file extension (e.g. ``"jpg"``).
 
     Returns:
-        List of image file paths
+        List of image file paths.
     """
-    patterns = ["*.jpg", "*.jpeg", "*.JPG", "*.JPEG", "*.png", "*.PNG"]
-    images = []
+    image_format = image_format.lower()
+    if image_format in {"jpg", "jpeg"}:
+        patterns = ["*.jpg", "*.jpeg", "*.JPG", "*.JPEG"]
+    else:
+        patterns = [f"*.{image_format}", f"*.{image_format.upper()}"]
+
+    images: List[Path] = []
     for pattern in patterns:
         images.extend(folder.glob(pattern))
     return sorted(images)
 
 
-def collect_images_recursive(root_dir: Path) -> List[Path]:
-    """Recursively collect all JPG/PNG images from root_dir.
+def collect_images_recursive(root_dir: Path, image_format: str = "jpg") -> List[Path]:
+    """Recursively collect images of a specific format from ``root_dir``.
 
     Args:
-        root_dir: Root directory to search recursively
+        root_dir: Root directory to search recursively.
+        image_format: Desired image file extension.
 
     Returns:
-        List of image file paths
+        List of image file paths.
     """
-    images = []
-    for pattern in ["*.jpg", "*.jpeg", "*.JPG", "*.JPEG", "*.png", "*.PNG"]:
+    image_format = image_format.lower()
+    if image_format in {"jpg", "jpeg"}:
+        patterns = ["*.jpg", "*.jpeg", "*.JPG", "*.JPEG"]
+    else:
+        patterns = [f"*.{image_format}", f"*.{image_format.upper()}"]
+
+    images: List[Path] = []
+    for pattern in patterns:
         images.extend(root_dir.rglob(pattern))
     return sorted(images)

--- a/scripts/detect_segment_images.py
+++ b/scripts/detect_segment_images.py
@@ -218,8 +218,9 @@ def process_video_folder(
     detector: ObjectDetector,
     segmenter: ObjectSegmenter,
     extra_tags: List[str] | None = None,
+    image_format: str = "jpg",
 ) -> None:
-    images = collect_images(folder)
+    images = collect_images(folder, image_format=image_format)
     if not images:
         return
 
@@ -276,6 +277,7 @@ def main() -> None:
 
     cfg = ConfigManager(config_file_path=str(args.config))
     cfg.load_config()
+    image_format = cfg.get_param("processing.image_format", "jpg")
     detector = ObjectDetector(cfg)
     segmenter = ObjectSegmenter(cfg)
 
@@ -288,10 +290,10 @@ def main() -> None:
     skipped_count = 0
 
     for sub in sorted(p for p in args.folder.iterdir() if p.is_dir()):
-        images = collect_images(sub)
+        images = collect_images(sub, image_format=image_format)
         if len(images) >= args.min_images:
             print(f"Processing video folder '{sub.name}' with {len(images)} images...")
-            process_video_folder(sub, detector, segmenter, extra_tags)
+            process_video_folder(sub, detector, segmenter, extra_tags, image_format)
             processed_count += 1
         else:
             print(

--- a/scripts/tag_images.py
+++ b/scripts/tag_images.py
@@ -76,9 +76,11 @@ def tagging_save_func(path: Path, result: Any, detectable_tags_keys: List[str]) 
     print(f"Saved tags for {path} -> {out_path}")
 
 
-def process_video_folder(folder: Path, lister, detectable_tags_keys: List[str]) -> None:
+def process_video_folder(
+    folder: Path, lister, detectable_tags_keys: List[str], image_format: str
+) -> None:
     """Annotate all images in a video folder with drivable area tags."""
-    images = collect_images(folder)
+    images = collect_images(folder, image_format=image_format)
     if not images:
         return
 
@@ -172,6 +174,7 @@ def main() -> None:
 
     cfg = ConfigManager(config_file_path=str(args.config))
     cfg.load_config()
+    image_format = cfg.get_param("processing.image_format", "jpg")
     # set custom task prompt for this task
 
     cfg.set_param("object_listing_settings.task_prompt", TASK_PROMPT)
@@ -185,10 +188,10 @@ def main() -> None:
     skipped_count = 0
 
     for sub in sorted(p for p in args.folder.iterdir() if p.is_dir()):
-        images = collect_images(sub)
+        images = collect_images(sub, image_format=image_format)
         if len(images) >= args.min_images:
             print(f"Processing video folder '{sub.name}' with {len(images)} images...")
-            process_video_folder(sub, lister, detectable_tags_keys)
+            process_video_folder(sub, lister, detectable_tags_keys, image_format)
             processed_count += 1
         else:
             print(


### PR DESCRIPTION
## Summary
- allow selecting image format via config files
- read this setting in `tag_images` and `detect_segment_images`
- collect images only in the chosen format
- document that `min-images` now depends on configured format

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e0a780ca0833389ceea5af08391a7