### PR TITLE
Handle zero row limit in Ray dataset example

### DIFF
--- a/cookbook/use_with_ray.py
+++ b/cookbook/use_with_ray.py
@@ -342,10 +342,11 @@ try:
         DATASET_PATH,
         columns=columns
     )
-    
+
     # Apply row limit if specified
-    if ROW_LIMIT > 0:
-        dataset = dataset.limit(ROW_LIMIT)
+    effective_limit = ROW_LIMIT if ROW_LIMIT > 0 else None
+    if effective_limit is not None:
+        dataset = dataset.limit(effective_limit)
     
     print(f"Loaded dataset with {dataset.count()} rows")
     print(f"Schema: {dataset.schema()}")
@@ -357,7 +358,8 @@ except Exception as e:
     
     # Create synthetic data
     synthetic_data = []
-    for i in range(min(ROW_LIMIT, 8)):
+    synthetic_rows = min(ROW_LIMIT, 8) if ROW_LIMIT > 0 else 8
+    for i in range(synthetic_rows):
         # Create a simple synthetic image (gradient)
         img_array = np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8)
         img_pil = Image.fromarray(img_array)
@@ -473,7 +475,8 @@ print(f"  - CPUs: {RAY_NUM_CPUS}")
 print(f"  - GPUs: {RAY_NUM_GPUS}")
 print(f"  - Batch size: {RAY_BATCH_SIZE}")
 print(f"  - Concurrency: {RAY_CONCURRENCY}")
-print(f"  - Row limit: {ROW_LIMIT}")
+row_limit_str = str(ROW_LIMIT) if ROW_LIMIT > 0 else "unlimited"
+print(f"  - Row limit: {row_limit_str}")
 
 # %% [markdown]
 # ## Cleanup

--- a/tests/test_use_with_ray_row_limit.py
+++ b/tests/test_use_with_ray_row_limit.py
@@ -1,0 +1,31 @@
+"""Tests for row limit behavior in use_with_ray example."""
+
+from __future__ import annotations
+
+import io
+import os
+from typing import List
+
+import numpy as np
+from PIL import Image
+
+
+def _create_synthetic_dataset() -> List[bytes]:
+    """Create synthetic image bytes matching cookbook example logic."""
+    row_limit = int(os.environ.get("LANCE_ROW_LIMIT", "16"))
+    synthetic_rows = min(row_limit, 8) if row_limit > 0 else 8
+    synthetic_data: List[bytes] = []
+    for _ in range(synthetic_rows):
+        img_array = np.random.randint(0, 255, (224, 224, 3), dtype=np.uint8)
+        img_pil = Image.fromarray(img_array)
+        img_bytes = io.BytesIO()
+        img_pil.save(img_bytes, format="JPEG")
+        synthetic_data.append(img_bytes.getvalue())
+    return synthetic_data
+
+
+def test_row_limit_zero(monkeypatch):
+    """When LANCE_ROW_LIMIT=0 the synthetic dataset should have 8 rows."""
+    monkeypatch.setenv("LANCE_ROW_LIMIT", "0")
+    dataset = _create_synthetic_dataset()
+    assert len(dataset) == 8


### PR DESCRIPTION
## Summary
- make row limit optional in `use_with_ray.py` via `effective_limit`
- ensure synthetic dataset creates default rows when limit is zero
- show `unlimited` row limit in processing summary
- test zero row limit behavior

## Testing
- `pytest tests/test_use_with_ray_row_limit.py::test_row_limit_zero -v`


------
https://chatgpt.com/codex/tasks/task_e_68bee499fb388333929ad064cbefa486