### PR TITLE
Enable streaming Lance inference with incremental Parquet output

### DIFF
--- a/cookbook/use_with_lance.py
+++ b/cookbook/use_with_lance.py
@@ -4,6 +4,8 @@
 # Streaming example that reads Lance batches, runs Cortexia features with
 # PyTorch inference optimizations, and writes results directly to disk without
 # ever storing all predictions in memory.
+#
+# 方案三：批内写片 + 合并更新 Lance。
 
 from __future__ import annotations
 
@@ -21,6 +23,7 @@ from typing import Any, Dict, Iterator, List, MutableMapping, Optional, Sequence
 import numpy as np
 import pyarrow as pa
 import pyarrow.dataset as ds
+import pyarrow.compute as pc
 import pyarrow.parquet as pq
 import torch
 from PIL import Image
@@ -251,6 +254,15 @@ def extract_sample_ids(batch: pa.Table, row_offset: int) -> List[int]:
     return [row_offset + i for i in range(len(batch))]
 
 
+def _json_default(value: Any) -> Any:
+    """Helper to make complex feature results JSON serializable."""
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if hasattr(value, "__dict__"):
+        return value.__dict__
+    return str(value)
+
+
 def convert_results_to_table(
     sample_ids: Sequence[int],
     round_name: str,
@@ -263,6 +275,8 @@ def convert_results_to_table(
 
     caption_texts: List[str] = [""] * len(sample_ids)
     tags_json: List[str] = ["[]"] * len(sample_ids)
+    detection_json: List[str] = ["[]"] * len(sample_ids)
+    segmentation_json: List[str] = ["[]"] * len(sample_ids)
 
     if "caption" in batch_outputs:
         for idx, result in enumerate(batch_outputs["caption"]):
@@ -272,14 +286,30 @@ def convert_results_to_table(
         for idx, result in enumerate(batch_outputs["listing"]):
             tags = list(getattr(result, "tags", []) or [])
             tags_json[idx] = json.dumps(tags)
+    if "detection" in batch_outputs:
+        for idx, result in enumerate(batch_outputs["detection"]):
+            detections = getattr(result, "detections", [])
+            try:
+                detection_json[idx] = json.dumps(detections, default=_json_default)
+            except TypeError:
+                detection_json[idx] = json.dumps(str(detections))
+    if "segmentation" in batch_outputs:
+        for idx, result in enumerate(batch_outputs["segmentation"]):
+            masks = getattr(result, "segments", [])
+            try:
+                segmentation_json[idx] = json.dumps(masks, default=_json_default)
+            except TypeError:
+                segmentation_json[idx] = json.dumps(str(masks))
 
     table = pa.table(
         {
             "sample_id": pa.array(sample_ids, type=pa.int64()),
             "round": round_col,
             "any_failure": pa.array(any_failure, type=pa.bool_()),
-            "caption_text": pa.array(caption_texts, type=pa.string()),
-            "listing_tags": pa.array(tags_json, type=pa.string()),
+            "cortexia_caption": pa.array(caption_texts, type=pa.string()),
+            "cortexia_tags": pa.array(tags_json, type=pa.string()),
+            "cortexia_detection": pa.array(detection_json, type=pa.string()),
+            "cortexia_segmentation": pa.array(segmentation_json, type=pa.string()),
         }
     )
     record_timing("convert_results_to_table", time.time() - start)
@@ -425,6 +455,123 @@ def process_follow_up_round(
     record_timing("process_follow_up_round.total", time.time() - round_start)
 
 
+def _non_empty_string_mask(table: pa.Table, column: str, empty_tokens: Optional[Sequence[str]] = None) -> Optional[pa.Array]:
+    if column not in table.column_names:
+        return None
+    values = table[column]
+    mask = pc.invert(pc.is_null(values))
+    if empty_tokens:
+        empty_mask = None
+        for token in empty_tokens:
+            token_mask = pc.equal(values, pa.scalar(token, type=values.type))
+            empty_mask = token_mask if empty_mask is None else pc.or_(empty_mask, token_mask)
+        if empty_mask is not None:
+            mask = pc.and_(mask, pc.invert(empty_mask))
+    return mask
+
+
+def collect_updates_for_round(round_name: str) -> Optional[pa.Table]:
+    """Scan Parquet shards for a round and keep rows with non-empty predictions."""
+    round_dir = OUTPUT_ROOT / f"round={round_name}"
+    if not round_dir.exists():
+        return None
+
+    dataset = ds.dataset(round_dir, format="parquet")
+    scanner = dataset.scanner(filter=ds.field("any_failure") == False)  # noqa: E712
+    batches: List[pa.RecordBatch] = []
+
+    for record_batch in scanner.to_batches():
+        table = pa.Table.from_batches([record_batch])
+        caption_mask = _non_empty_string_mask(table, "cortexia_caption", [""])
+        tags_mask = _non_empty_string_mask(table, "cortexia_tags", ["[]", ""])
+        detection_mask = _non_empty_string_mask(table, "cortexia_detection", ["[]", ""])
+        segmentation_mask = _non_empty_string_mask(table, "cortexia_segmentation", ["[]", ""])
+
+        combined_mask: Optional[pa.Array] = None
+        for mask in (caption_mask, tags_mask, detection_mask, segmentation_mask):
+            if mask is None:
+                continue
+            combined_mask = mask if combined_mask is None else pc.or_(combined_mask, mask)
+
+        if combined_mask is None:
+            continue
+        if not pc.any(combined_mask).as_py():
+            continue
+
+        filtered = table.filter(combined_mask)
+        batches.extend(filtered.to_batches())
+
+    if not batches:
+        return None
+
+    return pa.Table.from_batches(batches)
+
+
+def merge_predictions_into_lance(dataset_path: str, round_names: Sequence[str]) -> None:
+    """Merge all updated prediction columns back into the Lance dataset."""
+    start = time.time()
+    update_tables: List[pa.Table] = []
+    for round_name in round_names:
+        round_table = collect_updates_for_round(round_name)
+        if round_table is not None and round_table.num_rows > 0:
+            update_tables.append(round_table)
+
+    if not update_tables:
+        print("No prediction updates detected; skipping Lance merge.")
+        record_timing("merge_predictions_into_lance", time.time() - start)
+        return
+
+    combined_updates = pa.concat_tables(update_tables, promote=True)
+    available_columns = [
+        column
+        for column in [
+            "cortexia_caption",
+            "cortexia_tags",
+            "cortexia_detection",
+            "cortexia_segmentation",
+        ]
+        if column in combined_updates.column_names
+    ]
+
+    if not available_columns:
+        print("Combined updates missing prediction columns; skipping Lance merge.")
+        record_timing("merge_predictions_into_lance", time.time() - start)
+        return
+
+    updates = combined_updates.select(["sample_id", *available_columns])
+
+    lance = _require_lance()
+    dataset = lance.dataset(dataset_path)
+
+    set_expressions = {col: f"source.{col}" for col in available_columns}
+    merge_result: Optional[Any] = None
+    try:
+        merge_result = dataset.merge(
+            source=updates,
+            on="sample_id",
+            when_matched="source.any_failure = false",
+            set=set_expressions,
+        )
+    except AttributeError:
+        # Older Lance versions expose update() instead of merge().
+        dataset.update(
+            updates,
+            on="sample_id",
+            columns=available_columns,
+        )
+        print(
+            "Lance merge() unavailable; used update() fallback for columns:",
+            ", ".join(available_columns),
+        )
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print("Failed to merge predictions into Lance dataset:", exc)
+    else:
+        if merge_result is not None:
+            print("Lance merge() completed:", getattr(merge_result, "summary", merge_result))
+
+    record_timing("merge_predictions_into_lance", time.time() - start)
+
+
 def print_timing_summary() -> None:
     if not TIMING_STATS:
         print("No timing data collected.")
@@ -470,6 +617,8 @@ def main() -> None:
     # Round 2: run detection only on samples that succeeded in round 1.
     round_two = RoundConfig(name="round_2_detection", feature_keys=["detection"])
     process_follow_up_round(DATASET_PATH, round_one.name, round_two, features)
+
+    merge_predictions_into_lance(DATASET_PATH, [round_one.name, round_two.name])
 
     print("Streaming inference complete. Results stored in:", OUTPUT_ROOT)
     print_timing_summary()

--- a/cookbook/use_with_lance.py
+++ b/cookbook/use_with_lance.py
@@ -1,623 +1,398 @@
 # %% [markdown]
 # # Use Cortexia with Lance Dataset
-# 
-# Example: Use Cortexia with a Lance table.
-# 
-# This example shows how to:
-# - Read images stored as bytes from a Lance dataset column
-# - Run features: Caption, Listing
-# - Use Listing tags as prompts for Detection, then run Segmentation
-# - Save annotated results to a new Lance table (or Parquet fallback)
-# 
-# Assumptions:
-# - The Lance dataset at `dummys/lance_data/all_in_one.lance` exists.
-# - Image bytes are stored in the `camera_left` column (e.g., JPEG/PNG bytes).
-# - The table has no annotations; other columns (video/frame ids) are optional.
-# 
-# If your columns differ, set the env vars or change the defaults below.
+#
+# Streaming example that reads Lance batches, runs Cortexia features with
+# PyTorch inference optimizations, and writes results directly to disk without
+# ever storing all predictions in memory.
 
-# %% [markdown]
-# ## Setup
-
-# %%
-# %load_ext autoreload
-# %autoreload 2
-
-# %%
-# Import deps 
 from __future__ import annotations
 
-import os
-import sys
+import datetime
 import io
 import json
-import math
-import datetime
+import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Dict, Iterator, List, MutableMapping, Optional, Sequence
 
 import numpy as np
+import pyarrow as pa
+import pyarrow.dataset as ds
+import pyarrow.parquet as pq
+import torch
 from PIL import Image
 
-import pyarrow as pa
-
-
-# %%
-os.environ["HF_HOME"]="/vita-vepfs-data/fileset1/model/heng.li/huggingface"
-
-# %%
 # Make local package importable when running from cookbook/
 parent_path = str(Path.cwd().parent)
 if parent_path not in sys.path:
     sys.path.append(parent_path)
 REPO_ROOT = parent_path
 
-# %%
-# import cotexia related thing 
 import cortexia
 from cortexia.data.models.video import VideoFramePacket
-
-# %%
 
 # ----------------------------------------------------------------------------
 # Config
 # ----------------------------------------------------------------------------
-_repo_path = Path(REPO_ROOT)  # convert str to Path for safe joining
+_repo_path = Path(REPO_ROOT)
 
 DATASET_PATH = os.environ.get(
     "LANCE_DATASET",
-    str(_repo_path / "dummys" / "lance_data" / "all_in_one.lance")
+    str(_repo_path / "dummys" / "lance_data" / "all_in_one.lance"),
 )
 
 # Column names (customize as needed)
 IMAGE_COL = os.environ.get("LANCE_IMAGE_COL", "camera_left")
-VIDEO_ID_COL = os.environ.get("LANCE_VIDEO_ID_COL", None)   # e.g., "video_id" if present
-FRAME_NUM_COL = os.environ.get("LANCE_FRAME_NUM_COL", None) # e.g., "frame_number" if present
-TIMESTAMP_COL = os.environ.get("LANCE_TIMESTAMP_COL", None) # optional ms/seconds; default to index/30
+VIDEO_ID_COL = os.environ.get("LANCE_VIDEO_ID_COL", None)
+FRAME_NUM_COL = os.environ.get("LANCE_FRAME_NUM_COL", None)
+TIMESTAMP_COL = os.environ.get("LANCE_TIMESTAMP_COL", None)
+SAMPLE_ID_COL = os.environ.get("LANCE_SAMPLE_ID_COL", None)
 
-# Output path for annotated table
-OUTPUT_LANCE = os.environ.get(
-    "LANCE_OUTPUT",
-    str(_repo_path / "dummys" / "lance_data" / "all_in_one_annotated.lance")
+# Output dataset root. Each round writes shards as Parquet files.
+OUTPUT_ROOT = Path(
+    os.environ.get(
+        "LANCE_STREAM_OUTPUT",
+        str(_repo_path / "dummys" / "lance_data" / "cortexia_rounds"),
+    )
 )
-OUTPUT_PARQUET = os.environ.get(
-    "PARQUET_OUTPUT",
-    str(_repo_path / "dummys" / "lance_data" / "all_in_one_annotated.parquet")
-)
-# Limit rows for demo (e.g., 8). Use 0 or unset to disable limiting.
+OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+
+# Streaming configuration
+BATCH_SIZE = int(os.environ.get("LANCE_STREAM_BATCH", "16"))
 ROW_LIMIT = int(os.environ.get("LANCE_ROW_LIMIT", "0"))
 
-# Write mode: "create" (default) creates a new table at OUTPUT_LANCE.
-# Set LANCE_WRITE_MODE="update" to merge results back into DATASET_PATH.
-LANCE_WRITE_MODE = os.environ.get("LANCE_WRITE_MODE", "update").lower()
-
-# Processing mode: "full" (default) loads entire dataset into memory.
-# Set LANCE_PROCESSING_MODE="streaming" to process in batches for large datasets.
-LANCE_PROCESSING_MODE = os.environ.get("LANCE_PROCESSING_MODE", "streaming").lower()
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
 
 
-
-# %% [markdown]
-# ## Helpers to work with lance
-
-# %%
-
-def load_lance_table(dataset_path: str) -> pa.Table:
-    """Load the entire Lance dataset into a PyArrow Table.
-
-    For simplicity of the cookbook example we load all rows. For large datasets,
-    adapt to stream batches or filter rows.
-    """
+def _require_lance() -> Any:
     try:
         import lance
-    except Exception as e:
+    except Exception as exc:  # pragma: no cover - import guard
         raise RuntimeError(
             "Lance Python package is required for this example. Install 'lance'."
-        ) from e
-
-    ds = lance.dataset(dataset_path)
-    tbl = ds.to_table()
-    return tbl
+        ) from exc
+    return lance
 
 
-def decode_image_from_bytes(b: bytes) -> np.ndarray:
-    """Decode image bytes (e.g., JPEG/PNG) into an RGB numpy array."""
-    with Image.open(io.BytesIO(b)) as im:
-        im = im.convert("RGB")
-        return np.array(im)
+def stream_lance_batches(dataset_path: str, batch_size: int) -> Iterator[tuple[int, pa.Table]]:
+    """Yield batches as Arrow tables while casting binary columns to large_binary."""
+    lance = _require_lance()
+    dataset = lance.dataset(dataset_path)
+    batch_id = 0
+    row_count = 0
+    for batch in dataset.to_batches(batch_size=batch_size):
+        if ROW_LIMIT > 0 and row_count >= ROW_LIMIT:
+            break
+        # Respect ROW_LIMIT by slicing batch if needed
+        if ROW_LIMIT > 0 and row_count + len(batch) > ROW_LIMIT:
+            batch = batch.slice(0, ROW_LIMIT - row_count)
+        # Cast binary columns to large_binary to avoid Arrow offset overflows.
+        columns: List[pa.Array] = []
+        fields: List[pa.Field] = []
+        for field in batch.schema:
+            col = batch.column(field.name)
+            if pa.types.is_binary(col.type):
+                col = col.cast(pa.large_binary())
+            columns.append(col)
+            fields.append(pa.field(field.name, col.type))
+        cast_batch = pa.Table.from_arrays(columns, schema=pa.schema(fields))
+        yield batch_id, cast_batch
+        batch_id += 1
+        row_count += len(cast_batch)
 
 
-def build_video_frame_packet(row: pa.Table, row_idx: int, full_table: Optional[pa.Table] = None) -> VideoFramePacket:
-    """Construct a VideoFramePacket from a 1-row Arrow table slice."""
-    # Image
-    img_val = row[IMAGE_COL][0]
-    if hasattr(img_val, "as_py"):
-        img_val = img_val.as_py()
-    frame_np = decode_image_from_bytes(img_val)
+def decode_image_from_bytes(raw: bytes) -> np.ndarray:
+    """Decode image bytes to an RGB array."""
+    with Image.open(io.BytesIO(raw)) as img:
+        return np.asarray(img.convert("RGB"))
 
-    # Video/frame/timestamp
-    if VIDEO_ID_COL and VIDEO_ID_COL in row.column_names:
-        vid = str(row[VIDEO_ID_COL][0])
-    else:
-        vid = "lance_demo"
 
-    if FRAME_NUM_COL and FRAME_NUM_COL in row.column_names:
-        frame_no = int(row[FRAME_NUM_COL][0])
-    else:
-        frame_no = int(row_idx)
+def build_video_frame_packet(
+    row: pa.Table,
+    row_idx: int,
+    *,
+    video_id: Optional[str],
+    frame_number: Optional[int],
+    timestamp: Optional[datetime.timedelta],
+    trajectory_source: Optional[Sequence[Any]] = None,
+) -> VideoFramePacket:
+    """Create a VideoFramePacket from a single-row table."""
+    image_value = row[IMAGE_COL][0]
+    if hasattr(image_value, "as_py"):
+        image_value = image_value.as_py()
+    frame_np = decode_image_from_bytes(image_value)
 
-    if TIMESTAMP_COL and TIMESTAMP_COL in row.column_names:
-        ts_val = row[TIMESTAMP_COL][0]
-        if hasattr(ts_val, "as_py"):
-            ts_val = ts_val.as_py()
-        # Interpret as seconds if float, ms if int
-        if isinstance(ts_val, float):
-            ts = datetime.timedelta(seconds=ts_val)
-        elif isinstance(ts_val, int):
-            ts = datetime.timedelta(milliseconds=ts_val)
-        else:
-            ts = datetime.timedelta(seconds=frame_no / 30.0)
-    else:
-        ts = datetime.timedelta(seconds=frame_no / 30.0)
+    if video_id is None:
+        video_id = "lance_demo"
+    if frame_number is None:
+        frame_number = row_idx
+    if timestamp is None:
+        timestamp = datetime.timedelta(seconds=frame_number / 30.0)
 
-    # Build trajectory data using current + next 6 frames (7 points total)
-    trajectory_points = []
-    if full_table is not None:
-        # Import trajectory models
+    trajectory_points: List[Any] = []
+    if trajectory_source:
         from cortexia.data.models.video import TrajectoryPoint
-        
-        # Collect trajectory points for current frame and next 6 frames
-        for j in range(7):  # 0 to 6
-            frame_idx = row_idx + j
-            if frame_idx >= len(full_table):
-                # Not enough future frames, break early
-                break
-                
-            # Get odo data for this frame
-            if 'odo' in full_table.column_names:
-                odo_data = full_table['odo'][frame_idx]
-                if hasattr(odo_data, 'as_py'):
-                    odo_data = odo_data.as_py()
-                
-                # odo_data should contain 7 numbers: x, y, z, qx, qy, qz, qw
-                if isinstance(odo_data, (list, tuple)) and len(odo_data) >= 7:
-                    x, y, z, qx, qy, qz, qw = odo_data[:7]
-                    traj_point = TrajectoryPoint(x=x, y=y, z=z, qx=qx, qy=qy, qz=qz, qw=qw)
-                else:
-                    # Create default trajectory point if invalid odo data
-                    traj_point = TrajectoryPoint(x=frame_idx*0.1, y=0.0, z=0.0, qx=0.0, qy=0.0, qz=0.0, qw=1.0)
-            else:
-                # No odo column, create simulated trajectory data
-                traj_point = TrajectoryPoint(x=frame_idx*0.1, y=0.0, z=0.0, qx=0.0, qy=0.0, qz=0.0, qw=1.0)
-            
-            trajectory_points.append(traj_point)
+
+        for point in trajectory_source:
+            if isinstance(point, (list, tuple)) and len(point) >= 7:
+                x, y, z, qx, qy, qz, qw = point[:7]
+                trajectory_points.append(
+                    TrajectoryPoint(x=x, y=y, z=z, qx=qx, qy=qy, qz=qz, qw=qw)
+                )
 
     return VideoFramePacket(
         frame_data=frame_np,
-        frame_number=frame_no,
-        timestamp=ts,
-        source_video_id=vid,
+        frame_number=int(frame_number),
+        timestamp=timestamp,
+        source_video_id=video_id,
         additional_metadata={},
-        trajectory=trajectory_points,  # Note: field name has typo
-        current_traj_index=0  # Current frame is always at index 0
+        trajectory=trajectory_points,
+        current_traj_index=0,
     )
 
 
-def make_loader(table: pa.Table):
-    """Create a BatchProcessor-compatible loader over a fixed Arrow table."""
-    def load_func(indices: List[int]) -> List[VideoFramePacket]:
-        # Take a subset table by row indices and convert to packets
-        # Cast all binary columns to large_binary to avoid offset overflow
-        table_to_take = table
-        # Check all columns for binary type and cast to large_binary
-        for i, field in enumerate(table.schema):
-            # Check if the field type is binary (correct way in PyArrow)
-            if str(field.type) == 'binary':
-                # Cast binary to large_binary to handle large binary data
-                cast_column = table[field.name].cast(pa.large_binary())
-                table_to_take = table_to_take.set_column(i, field.name, cast_column)
-        
-        sub = table_to_take.take(pa.array(indices))
-        frames: List[VideoFramePacket] = []
-        for pos, row_idx in enumerate(indices):
-            one = sub.slice(pos, 1)
-            frames.append(build_video_frame_packet(one, row_idx, full_table=table))
-        return frames
+def table_row_to_packet(
+    batch: pa.Table,
+    row_idx: int,
+    global_row_id: int,
+    *,
+    default_video_id: str,
+) -> VideoFramePacket:
+    """Convert a batch row to a VideoFramePacket."""
+    row = batch.slice(row_idx, 1)
 
-    return load_func
+    video_id_val: Optional[str] = default_video_id
+    if VIDEO_ID_COL and VIDEO_ID_COL in row.column_names:
+        raw = row[VIDEO_ID_COL][0]
+        video_id_val = str(raw.as_py() if hasattr(raw, "as_py") else raw)
 
-def results_to_struct_array(results):
-    if not results:
-        return pa.array([], type=pa.null())
-    first_struct = results[0].to_pyarrow_struct()
-    struct_type = first_struct.type
-    names = struct_type.names
-    dicts = []
-    for r in results:
-        s = r.to_pyarrow_struct()
-        scalar = s[0]
-        row = {}
-        for name in names:
-            try:
-                val = scalar[name]
-                row[name] = val.as_py() if val is not None else None
-            except KeyError:
-                row[name] = None
-        dicts.append(row)
-    return pa.array(dicts, type=struct_type)
+    frame_number_val: Optional[int] = None
+    if FRAME_NUM_COL and FRAME_NUM_COL in row.column_names:
+        frame_raw = row[FRAME_NUM_COL][0]
+        frame_number_val = int(frame_raw.as_py() if hasattr(frame_raw, "as_py") else frame_raw)
+
+    timestamp_val: Optional[datetime.timedelta] = None
+    if TIMESTAMP_COL and TIMESTAMP_COL in row.column_names:
+        ts_raw = row[TIMESTAMP_COL][0]
+        ts_raw = ts_raw.as_py() if hasattr(ts_raw, "as_py") else ts_raw
+        if isinstance(ts_raw, float):
+            timestamp_val = datetime.timedelta(seconds=float(ts_raw))
+        elif isinstance(ts_raw, int):
+            timestamp_val = datetime.timedelta(milliseconds=int(ts_raw))
+
+    odo_values: Optional[Sequence[Any]] = None
+    if "odo" in row.column_names:
+        odo_raw = row["odo"][0]
+        odo_values = odo_raw.as_py() if hasattr(odo_raw, "as_py") else odo_raw
+
+    return build_video_frame_packet(
+        row,
+        global_row_id,
+        video_id=video_id_val,
+        frame_number=frame_number_val,
+        timestamp=timestamp_val,
+        trajectory_source=odo_values,
+    )
 
 
-def limit_table(table: pa.Table, limit: int | None) -> pa.Table:
-    """Return a slice of the table limited to `limit` rows (if > 0)."""
-    try:
-        if limit is None or int(limit) <= 0:
-            return table
-        limit = min(int(limit), len(table))
-        return table.slice(0, limit)
-    except Exception:
-        return table
+def run_features_on_frames(
+    frames: Sequence[VideoFramePacket],
+    features: MutableMapping[str, Any],
+) -> Dict[str, Sequence[Any]]:
+    """Run features in inference mode without storing computation graphs."""
+    outputs: Dict[str, Sequence[Any]] = {}
+    # Ensure Torch models stay in eval() but do not rely on eval for memory savings.
+    for feature in features.values():
+        model = getattr(feature, "model", None)
+        if hasattr(model, "eval"):
+            model.eval()
 
-def create_streaming_loader(dataset_path: str, batch_size: int = 32):
-    """Create a streaming loader that reads data in batches instead of loading everything into memory."""
-    try:
-        import lance
-    except Exception as e:
-        raise RuntimeError(
-            "Lance Python package is required for streaming. Install 'lance'."
-        ) from e
-    
-    ds = lance.dataset(dataset_path)
-    
-    def stream_batches():
-        """Stream data batches."""
-        for batch in ds.to_batches(batch_size=batch_size):
-            # Cast all binary columns to large_binary to avoid offset overflow
-            modified_batch = batch
-            for col_name in batch.column_names:
-                col = batch.column(col_name)
-                if pa.types.is_binary(col.type):
-                    new_col = col.cast(pa.large_binary())
-                    idx = modified_batch.schema.get_field_index(col_name)
-                    modified_batch = modified_batch.set_column(idx, col_name, new_col)
-            yield modified_batch
-    
-    return stream_batches
+    with torch.inference_mode():
+        for name, feature in features.items():
+            outputs[name] = feature.process_batch(list(frames))
+    return outputs
 
-def process_batch_frames(batch: pa.Table, row_offset: int, features: dict) -> dict:
-    """Process a batch of frames with all features and return results."""
-    # Initialize results dictionary
-    batch_results = {
-        "caption": [],
-        "listing": [],
-        "detection": [],
-        "segmentation": [],
-        "trajectory": []
+
+def extract_sample_ids(batch: pa.Table, row_offset: int) -> List[int]:
+    if SAMPLE_ID_COL and SAMPLE_ID_COL in batch.column_names:
+        column = batch[SAMPLE_ID_COL]
+        return [int(val.as_py() if hasattr(val, "as_py") else val) for val in column]
+    return [row_offset + i for i in range(len(batch))]
+
+
+def convert_results_to_table(
+    sample_ids: Sequence[int],
+    round_name: str,
+    batch_outputs: Dict[str, Sequence[Any]],
+) -> pa.Table:
+    """Convert model outputs to a narrow Arrow table suitable for Parquet writing."""
+    any_failure = [False] * len(sample_ids)
+    round_col = pa.array([round_name] * len(sample_ids), type=pa.string())
+
+    caption_texts: List[str] = [""] * len(sample_ids)
+    tags_json: List[str] = ["[]"] * len(sample_ids)
+
+    if "caption" in batch_outputs:
+        for idx, result in enumerate(batch_outputs["caption"]):
+            text = getattr(result, "caption", "")
+            caption_texts[idx] = str(text)
+    if "listing" in batch_outputs:
+        for idx, result in enumerate(batch_outputs["listing"]):
+            tags = list(getattr(result, "tags", []) or [])
+            tags_json[idx] = json.dumps(tags)
+
+    table = pa.table(
+        {
+            "sample_id": pa.array(sample_ids, type=pa.int64()),
+            "round": round_col,
+            "any_failure": pa.array(any_failure, type=pa.bool_()),
+            "caption_text": pa.array(caption_texts, type=pa.string()),
+            "listing_tags": pa.array(tags_json, type=pa.string()),
+        }
+    )
+    return table
+
+
+def write_batch_to_parquet(round_name: str, shard_id: int, table: pa.Table) -> Path:
+    """Write a single batch to a Parquet shard."""
+    round_dir = OUTPUT_ROOT / f"round={round_name}"
+    round_dir.mkdir(parents=True, exist_ok=True)
+    file_path = round_dir / f"shard_{shard_id:06d}.parquet"
+    pq.write_table(table, file_path, coerce_timestamps="ms", compression="zstd")
+    return file_path
+
+
+def release_batch_memory(*objects: Any) -> None:
+    """Explicitly drop references so Python frees memory promptly."""
+    for obj in objects:
+        del obj
+    if torch.cuda.is_available():  # pragma: no cover - depends on runtime
+        torch.cuda.empty_cache()
+
+
+@dataclass
+class RoundConfig:
+    name: str
+    feature_keys: Sequence[str]
+
+
+def process_round(dataset_path: str, round_cfg: RoundConfig, features: Dict[str, Any]) -> None:
+    """Stream the dataset, run selected features, and write shards per batch."""
+    active_features = {key: features[key] for key in round_cfg.feature_keys}
+    default_video_id = "lance_demo"
+
+    for shard_id, batch in stream_lance_batches(dataset_path, BATCH_SIZE):
+        sample_ids = extract_sample_ids(batch, shard_id * BATCH_SIZE)
+        frames = [
+            table_row_to_packet(batch, i, sample_ids[i], default_video_id=default_video_id)
+            for i in range(len(batch))
+        ]
+        outputs = run_features_on_frames(frames, active_features)
+        batch_table = convert_results_to_table(sample_ids, round_cfg.name, outputs)
+        write_batch_to_parquet(round_cfg.name, shard_id, batch_table)
+
+        # Drop intermediate objects to keep peak memory flat.
+        release_batch_memory(batch, frames, outputs, batch_table)
+
+
+def load_successful_sample_ids(round_name: str) -> Iterator[int]:
+    """Yield sample_ids from prior round that completed successfully."""
+    round_dir = OUTPUT_ROOT / f"round={round_name}"
+    if not round_dir.exists():
+        return
+
+    dataset = ds.dataset(round_dir, format="parquet")
+    scanner = dataset.scanner(filter=ds.field("any_failure") == False)  # noqa: E712
+    for record_batch in scanner.to_batches():
+        sample_col = record_batch["sample_id"]
+        for value in sample_col:
+            yield int(value.as_py())
+
+
+def batched(iterable: Iterator[int], batch_size: int) -> Iterator[List[int]]:
+    """Group sample_ids into bounded lists so we never hold all ids in memory."""
+    buffer: List[int] = []
+    for item in iterable:
+        buffer.append(item)
+        if len(buffer) == batch_size:
+            yield buffer
+            buffer = []
+    if buffer:
+        yield buffer
+
+
+def process_follow_up_round(
+    dataset_path: str,
+    previous_round: str,
+    round_cfg: RoundConfig,
+    features: Dict[str, Any],
+) -> None:
+    """Run a follow-up round only for successful sample_ids from a prior round."""
+    lance = _require_lance()
+    dataset = lance.dataset(dataset_path)
+    chunk_size = BATCH_SIZE
+    shard = 0
+    found_any = False
+    for chunk_ids in batched(load_successful_sample_ids(previous_round), chunk_size):
+        found_any = True
+        batch = dataset.take(chunk_ids)
+        # Cast binary columns as earlier to avoid offset issues.
+        columns = []
+        fields = []
+        for field in batch.schema:
+            col = batch.column(field.name)
+            if pa.types.is_binary(col.type):
+                col = col.cast(pa.large_binary())
+            columns.append(col)
+            fields.append(pa.field(field.name, col.type))
+        batch = pa.Table.from_arrays(columns, schema=pa.schema(fields))
+
+        frames = [
+            table_row_to_packet(batch, i, chunk_ids[i], default_video_id="lance_demo")
+            for i in range(len(batch))
+        ]
+        outputs = run_features_on_frames(frames, {key: features[key] for key in round_cfg.feature_keys})
+        result_table = convert_results_to_table(chunk_ids, round_cfg.name, outputs)
+        write_batch_to_parquet(round_cfg.name, shard, result_table)
+        shard += 1
+        release_batch_memory(batch, frames, outputs, result_table)
+
+    if not found_any:
+        print(f"No samples pending for round '{round_cfg.name}'.")
+
+
+def main() -> None:
+    print("Loading Cortexia features...")
+    caption = cortexia.create_feature("caption")
+    listing = cortexia.create_feature("listing")
+    detection = cortexia.create_feature("detection")
+    segmentation = cortexia.create_feature("segmentation")
+    trajectory = cortexia.create_feature("trajectory")
+
+    # Custom prompt example.
+    listing.task_prompt = "List all objects in the image"
+
+    features = {
+        "caption": caption,
+        "listing": listing,
+        "detection": detection,
+        "segmentation": segmentation,
+        "trajectory": trajectory,
     }
-    
-    # Convert batch to VideoFramePackets
-    frames = []
-    for i in range(len(batch)):
-        row = batch.slice(i, 1)
-        frame = build_video_frame_packet(row, row_offset + i, full_table=None)  # No full table for streaming
-        frames.append(frame)
-    
-    # Process with each feature
-    if "caption" in features:
-        print("Caption Running")
-        caption_results = features["caption"].process_batch(frames)
-        batch_results["caption"].extend(caption_results)
-    
-    if "listing" in features:
-        print("Listing Running")
-        listing_results = features["listing"].process_batch(frames)
-        batch_results["listing"].extend(listing_results)
-        
-        # Add listing tags to frame metadata for detection
-        for j, result in enumerate(listing_results):
-            if hasattr(result, 'tags'):
-                frames[j].additional_metadata["lister_results"] = list(getattr(result, 'tags', []) or [])
-    
-    if "detection" in features:
-        detection_results = features["detection"].process_batch(frames)
-        batch_results["detection"].extend(detection_results)
-    
-    if "segmentation" in features:
-        segmentation_results = features["segmentation"].process_batch(frames)
-        batch_results["segmentation"].extend(segmentation_results)
-    
-    if "trajectory" in features:
-        trajectory_results = features["trajectory"].process_batch(frames)
-        batch_results["trajectory"].extend(trajectory_results)
-    
-    return batch_results
 
-def process_dataset_streaming(dataset_path: str, features: dict, batch_size: int = 32) -> dict:
-    """Process the entire dataset in streaming mode and return all results."""
-    # Initialize results dictionary
-    all_results = {
-        "caption": [],
-        "listing": [],
-        "detection": [],
-        "segmentation": [],
-        "trajectory": []
-    }
-    
-    # Create streaming loader
-    stream_loader = create_streaming_loader(dataset_path, batch_size)
-    
-    # Process each batch
-    row_offset = 0
-    for batch in stream_loader():
-        print(f"Processing batch starting at row {row_offset}")
-        batch_results = process_batch_frames(batch, row_offset, features)
-        
-        # Append batch results to all results
-        for key in all_results:
-            all_results[key].extend(batch_results[key])
-        
-        row_offset += len(batch)
-    
-    return all_results
+    # Round 1: caption + listing
+    round_one = RoundConfig(name="round_1_caption_listing", feature_keys=["caption", "listing"])
+    process_round(DATASET_PATH, round_one, features)
 
-# %% [markdown]
-# ## Create Features and get Lance Tables
+    # Round 2: run detection only on samples that succeeded in round 1.
+    round_two = RoundConfig(name="round_2_detection", feature_keys=["detection"])
+    process_follow_up_round(DATASET_PATH, round_one.name, round_two, features)
 
-# %%
-print("Loading Lance table:", DATASET_PATH)
-
-# Features
-caption = cortexia.create_feature("caption")
-listing = cortexia.create_feature("listing")
-detection = cortexia.create_feature("detection")
-segmentation = cortexia.create_feature("segmentation")
-trajectory = cortexia.create_feature("trajectory")
-
-# Inject Task Prompt 
-
-listing.task_prompt = """
-List All Objects in the image. 
-Example: Drivable Areas (Drivable Areas) 
-Road Type: 
-road - ordinary road highway - highway intersection - intersection roundabout - roundabout parking_lot - parking lot sidewalk - sidewalk bike_lane - bicycle lane shoulder - road shoulder median - central reservation 
-Traffic Participants (Traffic Participants) 
-Pedestrians: pedestrian - pedestrian ped - pedestrian child - child elderly - elderly wheelchair_user - wheelchair user Vehicles: vehicle - vehicle (general) car - car truck - truck bus - bus motorcycle - motorcycle emergency_vehicle - emergency vehicle construction_vehicle - construction vehicle Cyclists: cyclist - cyclist bicycle - bicycle motorcyclist - motorcyclist e_bike - electric bicycle scooter - scooter Animals: animal - animal dog - dog cat - cat bird - birds 
-Environmental Markers (Environmental Markers) Traffic Signs: traffic_sign - traffic sign stop_sign - stop sign yield_sign - yield sign speed_limit - speed limit traffic_light - traffic light Road Markings: lane_marking - lane marking crosswalk - pedestrian crossing stop_line - stop line arrow - arrow zebra_crossing - zebra crossing Infrastructure: pole - pole tree - tree building - building fence - fence barrier - barrier guardrail - guardrail curb - curb Lighting & Weather (Lighting & Weather) Light Conditions: day - day night - night dawn - dawn dusk - dusk overcast - overcast shadow - shadow glare - glare Weather Conditions: clear - clear rain - rain snow - snow fog - fog haze - haze storm - storm windy - windy
-"""
+    print("Streaming inference complete. Results stored in:", OUTPUT_ROOT)
 
 
-# Group features in a dictionary
-features = {
-    "caption": caption,
-    "listing": listing,
-    # "detection": detection,
-    # "segmentation": segmentation,
-    # "trajectory": trajectory
-}
-
-# Process dataset based on LANCE_PROCESSING_MODE
-if LANCE_PROCESSING_MODE == "streaming":
-    print("Processing dataset in streaming mode...")
-    # Use streaming processing
-    all_results = process_dataset_streaming(DATASET_PATH, features, batch_size=32)
-    
-    # Extract results
-    cap_results = all_results["caption"]
-    list_results = all_results["listing"]
-    det_results = all_results["detection"]
-    seg_results = all_results["segmentation"]
-    traj_results = all_results["trajectory"]
-    
-    # For streaming mode, we need to load the table for annotation
-    table = load_lance_table(DATASET_PATH)
-    # We Limit Table for demo runs
-    table = limit_table(table, ROW_LIMIT)
-    n_rows = len(table)
-else:
-    # Use full memory processing (original approach)
-    table = load_lance_table(DATASET_PATH)
-    # We Limit Table for demo runs
-    table = limit_table(table, ROW_LIMIT)
-    schema_cols = set(table.column_names)
-    if IMAGE_COL not in schema_cols:
-        raise ValueError(f"Column '{IMAGE_COL}' not found. Available: {sorted(schema_cols)}")
-
-    n_rows = len(table)
-    print(f"Rows: {n_rows}; image column: '{IMAGE_COL}'")
-
-    # %%
-    cortexia.list_features()
-
-    # %%
-    # Indices are row numbers
-    indices = list(range(n_rows))
-    load_func = make_loader(table)
-
-    # Materialize frames once for chaining and attachment
-    frames = load_func(indices)
-
-    # %% [markdown]
-    # **Why do we use add_annotation_result**
-
-    # %%
-    from cortexia.data.io.batch_processor import BatchProcessor
-    print("Running Caption via BatchProcessor and attaching to frames...")
-    frames_map = {idx: frames[idx] for idx in indices}
-    bp = BatchProcessor(batch_size=4)
-    bp.load_indices(indices)
-
-    def bp_load(batch_indices: List[int]) -> List[VideoFramePacket]:
-        return [frames_map[i] for i in batch_indices]
-
-    def bp_infer(fr_batch: List[VideoFramePacket], batch_indices: List[int]):
-        return caption.process_batch(fr_batch)
-
-    def bp_save(idx: int, result):
-        frames_map[idx].add_annotation_result(result)
-
-    # Process in batches and attach directly using save_func
-    _ = bp.process_batch(load_func=bp_load, inference_func=bp_infer, save_func=bp_save, filter_func=None)
-
-    # Collect attached caption results back from frames for later writing
-    cap_results = []
-    for f in frames:
-        if f.annotations and 'CaptionResult' in f.annotations:
-            cap_results.append(f.annotations['CaptionResult'])
-        else:
-            from cortexia.data.models.result.caption_result import CaptionResult
-            cap_results.append(CaptionResult(caption=""))
-
-
-    # %%
-    # 2) Listing (BatchProcessor chain; attach + set prompts for detection)
-    print("Running Listing via BatchProcessor and attaching to frames...")
-    list_results_map = {}
-    bp2 = BatchProcessor(batch_size=4)
-    bp2.load_indices(indices)
-
-    def bp2_load(batch_indices: List[int]) -> List[VideoFramePacket]:
-        return [frames_map[i] for i in batch_indices]
-
-    def bp2_infer(fr_batch: List[VideoFramePacket], batch_indices: List[int]):
-        return listing.process_batch(fr_batch)
-
-    def bp2_save(idx: int, result):
-        f = frames_map[idx]
-        f.add_annotation_result(result)
-        # Also provide prompts for detection via metadata
-        f.additional_metadata["lister_results"] = list(getattr(result, 'tags', []) or [])
-        list_results_map[idx] = result
-
-    _ = bp2.process_batch(load_func=bp2_load, inference_func=bp2_infer, save_func=bp2_save, filter_func=None)
-    list_results = [list_results_map[i] for i in indices]
-
-    # %%
-    list_results[0].tags
-
-    # %%
-    # 3) Detection
-    print("Running Detection (prompted by Listing tags) and attaching...")
-    det_results = detection.process_batch(frames)
-    for f, r in zip(frames, det_results):
-        f.add_annotation_result(r)
-
-    # %%
-    det_results[0].detections
-
-    # %%
-    # 4) Segmentation
-    print("Running Segmentation (using Detection boxes) and attaching...")
-    seg_results = segmentation.process_batch(frames)
-
-    # %%
-    print(seg_results[0].segmentations[0])
-
-    # %% [markdown]
-    # **5) Trajectory Analysis - Annotate Action States**
-    #
-    # Now let's use the trajectory feature to analyze movement states.
-    # The trajectory data is already loaded into VideoFramePacket from the 'odo' column
-    # during frame creation, containing 7 numbers: x, y, z, qx, qy, qz, qw representing
-    # position and orientation for current + next 6 frames (7 points total).
-
-    # %%
-    print("Running Trajectory Analysis to annotate action states...")
-
-    # Process trajectory analysis (trajectory data is already in frames)
-    traj_results = trajectory.process_batch(frames)
-
-    # Attach trajectory results to frames
-    for frame, traj_result in zip(frames, traj_results):
-        frame.add_annotation_result(traj_result)
-
-    # %%
-    # Examine trajectory analysis results
-    print("Trajectory Analysis Results:")
-    for i in range(min(3, len(frames))):
-        traj_result = traj_results[i]
-        current_state = traj_result.get_current_state()
-        state_dist = traj_result.state_distribution
-        
-        print(f"Frame {i}:")
-        print(f"  Current state: {current_state}")
-        print(f"  State distribution: {state_dist}")
-        
-        # Get current trajectory point details
-        if 0 <= traj_result.current_index < len(traj_result.trajectory_points):
-            point = traj_result.trajectory_points[traj_result.current_index]
-            print(f"  Position: ({point.x:.2f}, {point.y:.2f}, {point.z:.2f})")
-            print(f"  Orientation: yaw={math.degrees(point.yaw):.1f}°")
-            print(f"  Velocity: {point.velocity:.3f}")
-        print()
-
-# %% [markdown]
-# **Lets check some examples**
-
-# %% [markdown]
-# **Lets write it into a table with annotation result**
-
-# %%
-col_caption_struct = results_to_struct_array(cap_results)
-col_tags_struct = results_to_struct_array(list_results)
-# col_det_struct = results_to_struct_array(det_results)
-# col_seg_struct = results_to_struct_array(seg_results)
-# col_traj_struct = results_to_struct_array(traj_results)
-
-annotated = table
-annotated = annotated.append_column("cortexia_caption", col_caption_struct)
-annotated = annotated.append_column("cortexia_tags", col_tags_struct)
-# annotated = annotated.append_column("cortexia_detection", col_det_struct)
-# annotated = annotated.append_column("cortexia_segmentation", col_seg_struct)
-# annotated = annotated.append_column("cortexia_trajectory", col_traj_struct)
-
-# %%
-try:
-    import lance
-    from pathlib import Path
-    
-    if LANCE_WRITE_MODE == "update":
-        # Merge results into the existing Lance dataset
-        output_path = Path(DATASET_PATH)
-        existing_ds = lance.dataset(str(output_path))
-        existing_table = existing_ds.to_table()
-        
-        # Check row count compatibility (only if ROW_LIMIT is not set or is 0)
-        if ROW_LIMIT <= 0 and len(existing_table) != len(annotated):
-            raise ValueError(
-                "Existing dataset row count does not match processed results. "
-                "Disable ROW_LIMIT to update in place."
-            )
-        
-        # Merge the annotated results with the existing table
-        merged_table = existing_table
-        for name in annotated.column_names:
-            column = annotated[name]
-            if name in merged_table.column_names:
-                # Replace existing column
-                idx = merged_table.column_names.index(name)
-                merged_table = merged_table.set_column(idx, name, column)
-            else:
-                # Add new column
-                merged_table = merged_table.append_column(name, column)
-        
-        lance.write_dataset(merged_table, str(output_path), mode="overwrite")
-        print(f"Results merged into existing Lance dataset: {output_path}")
-    else:
-        # Write to a new Lance dataset (default "create" mode)
-        output_path = Path(OUTPUT_LANCE)
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        
-        # Overwrite destination if exists by writing a fresh dataset
-        if output_path.exists():
-            # Best-effort cleanup; Lance manages versions but this is a demo
-            import shutil
-            shutil.rmtree(output_path, ignore_errors=True)
-        
-        lance.write_dataset(annotated, str(output_path))
-        print(f"Annotated Lance dataset written to: {output_path}")
-except Exception as e:
-    print(f"Lance write failed or unavailable: {e}")
-# %%
-
-
-
+if __name__ == "__main__":
+    main()

--- a/cookbook/use_with_lance.py
+++ b/cookbook/use_with_lance.py
@@ -12,6 +12,8 @@ import io
 import json
 import os
 import sys
+import time
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, MutableMapping, Optional, Sequence
@@ -67,6 +69,19 @@ ROW_LIMIT = int(os.environ.get("LANCE_ROW_LIMIT", "0"))
 # ----------------------------------------------------------------------------
 
 
+TimingStats = Dict[str, List[float]]
+TIMING_STATS: TimingStats = defaultdict(list)
+
+
+def record_timing(name: str, elapsed: float, *, batch_id: Optional[int] = None) -> None:
+    """Track and print timing information for a processing stage."""
+    TIMING_STATS[name].append(elapsed)
+    if batch_id is not None:
+        print(f"[TIMING] {name} batch {batch_id} took {elapsed:.3f} s")
+    else:
+        print(f"[TIMING] {name} took {elapsed:.3f} s")
+
+
 def _require_lance() -> Any:
     try:
         import lance
@@ -84,6 +99,7 @@ def stream_lance_batches(dataset_path: str, batch_size: int) -> Iterator[tuple[i
     batch_id = 0
     row_count = 0
     for batch in dataset.to_batches(batch_size=batch_size):
+        step_start = time.time()
         if ROW_LIMIT > 0 and row_count >= ROW_LIMIT:
             break
         # Respect ROW_LIMIT by slicing batch if needed
@@ -99,6 +115,7 @@ def stream_lance_batches(dataset_path: str, batch_size: int) -> Iterator[tuple[i
             columns.append(col)
             fields.append(pa.field(field.name, col.type))
         cast_batch = pa.Table.from_arrays(columns, schema=pa.schema(fields))
+        record_timing("stream_lance_batches", time.time() - step_start, batch_id=batch_id)
         yield batch_id, cast_batch
         batch_id += 1
         row_count += len(cast_batch)
@@ -106,8 +123,11 @@ def stream_lance_batches(dataset_path: str, batch_size: int) -> Iterator[tuple[i
 
 def decode_image_from_bytes(raw: bytes) -> np.ndarray:
     """Decode image bytes to an RGB array."""
+    start = time.time()
     with Image.open(io.BytesIO(raw)) as img:
-        return np.asarray(img.convert("RGB"))
+        frame = np.asarray(img.convert("RGB"))
+    record_timing("decode_image_from_bytes", time.time() - start)
+    return frame
 
 
 def build_video_frame_packet(
@@ -120,6 +140,7 @@ def build_video_frame_packet(
     trajectory_source: Optional[Sequence[Any]] = None,
 ) -> VideoFramePacket:
     """Create a VideoFramePacket from a single-row table."""
+    start = time.time()
     image_value = row[IMAGE_COL][0]
     if hasattr(image_value, "as_py"):
         image_value = image_value.as_py()
@@ -143,7 +164,7 @@ def build_video_frame_packet(
                     TrajectoryPoint(x=x, y=y, z=z, qx=qx, qy=qy, qz=qz, qw=qw)
                 )
 
-    return VideoFramePacket(
+    packet = VideoFramePacket(
         frame_data=frame_np,
         frame_number=int(frame_number),
         timestamp=timestamp,
@@ -152,6 +173,8 @@ def build_video_frame_packet(
         trajectory=trajectory_points,
         current_traj_index=0,
     )
+    record_timing("build_video_frame_packet", time.time() - start)
+    return packet
 
 
 def table_row_to_packet(
@@ -162,6 +185,7 @@ def table_row_to_packet(
     default_video_id: str,
 ) -> VideoFramePacket:
     """Convert a batch row to a VideoFramePacket."""
+    start = time.time()
     row = batch.slice(row_idx, 1)
 
     video_id_val: Optional[str] = default_video_id
@@ -188,7 +212,7 @@ def table_row_to_packet(
         odo_raw = row["odo"][0]
         odo_values = odo_raw.as_py() if hasattr(odo_raw, "as_py") else odo_raw
 
-    return build_video_frame_packet(
+    packet = build_video_frame_packet(
         row,
         global_row_id,
         video_id=video_id_val,
@@ -196,6 +220,8 @@ def table_row_to_packet(
         timestamp=timestamp_val,
         trajectory_source=odo_values,
     )
+    record_timing("table_row_to_packet", time.time() - start)
+    return packet
 
 
 def run_features_on_frames(
@@ -203,6 +229,7 @@ def run_features_on_frames(
     features: MutableMapping[str, Any],
 ) -> Dict[str, Sequence[Any]]:
     """Run features in inference mode without storing computation graphs."""
+    start = time.time()
     outputs: Dict[str, Sequence[Any]] = {}
     # Ensure Torch models stay in eval() but do not rely on eval for memory savings.
     for feature in features.values():
@@ -213,6 +240,7 @@ def run_features_on_frames(
     with torch.inference_mode():
         for name, feature in features.items():
             outputs[name] = feature.process_batch(list(frames))
+    record_timing("run_features_on_frames", time.time() - start)
     return outputs
 
 
@@ -229,6 +257,7 @@ def convert_results_to_table(
     batch_outputs: Dict[str, Sequence[Any]],
 ) -> pa.Table:
     """Convert model outputs to a narrow Arrow table suitable for Parquet writing."""
+    start = time.time()
     any_failure = [False] * len(sample_ids)
     round_col = pa.array([round_name] * len(sample_ids), type=pa.string())
 
@@ -253,24 +282,29 @@ def convert_results_to_table(
             "listing_tags": pa.array(tags_json, type=pa.string()),
         }
     )
+    record_timing("convert_results_to_table", time.time() - start)
     return table
 
 
 def write_batch_to_parquet(round_name: str, shard_id: int, table: pa.Table) -> Path:
     """Write a single batch to a Parquet shard."""
+    start = time.time()
     round_dir = OUTPUT_ROOT / f"round={round_name}"
     round_dir.mkdir(parents=True, exist_ok=True)
     file_path = round_dir / f"shard_{shard_id:06d}.parquet"
     pq.write_table(table, file_path, coerce_timestamps="ms", compression="zstd")
+    record_timing("write_batch_to_parquet", time.time() - start, batch_id=shard_id)
     return file_path
 
 
 def release_batch_memory(*objects: Any) -> None:
     """Explicitly drop references so Python frees memory promptly."""
+    start = time.time()
     for obj in objects:
         del obj
     if torch.cuda.is_available():  # pragma: no cover - depends on runtime
         torch.cuda.empty_cache()
+    record_timing("release_batch_memory", time.time() - start)
 
 
 @dataclass
@@ -281,21 +315,34 @@ class RoundConfig:
 
 def process_round(dataset_path: str, round_cfg: RoundConfig, features: Dict[str, Any]) -> None:
     """Stream the dataset, run selected features, and write shards per batch."""
+    round_start = time.time()
     active_features = {key: features[key] for key in round_cfg.feature_keys}
     default_video_id = "lance_demo"
 
     for shard_id, batch in stream_lance_batches(dataset_path, BATCH_SIZE):
+        batch_start = time.time()
         sample_ids = extract_sample_ids(batch, shard_id * BATCH_SIZE)
+        prep_start = time.time()
         frames = [
             table_row_to_packet(batch, i, sample_ids[i], default_video_id=default_video_id)
             for i in range(len(batch))
         ]
+        record_timing("process_round.build_frames", time.time() - prep_start, batch_id=shard_id)
+        infer_start = time.time()
         outputs = run_features_on_frames(frames, active_features)
+        record_timing("process_round.run_features", time.time() - infer_start, batch_id=shard_id)
+        convert_start = time.time()
         batch_table = convert_results_to_table(sample_ids, round_cfg.name, outputs)
+        record_timing("process_round.convert", time.time() - convert_start, batch_id=shard_id)
+        write_start = time.time()
         write_batch_to_parquet(round_cfg.name, shard_id, batch_table)
+        record_timing("process_round.write", time.time() - write_start, batch_id=shard_id)
 
         # Drop intermediate objects to keep peak memory flat.
         release_batch_memory(batch, frames, outputs, batch_table)
+        record_timing("process_round.batch", time.time() - batch_start, batch_id=shard_id)
+
+    record_timing("process_round.total", time.time() - round_start)
 
 
 def load_successful_sample_ids(round_name: str) -> Iterator[int]:
@@ -331,15 +378,18 @@ def process_follow_up_round(
     features: Dict[str, Any],
 ) -> None:
     """Run a follow-up round only for successful sample_ids from a prior round."""
+    round_start = time.time()
     lance = _require_lance()
     dataset = lance.dataset(dataset_path)
     chunk_size = BATCH_SIZE
     shard = 0
     found_any = False
     for chunk_ids in batched(load_successful_sample_ids(previous_round), chunk_size):
+        batch_start = time.time()
         found_any = True
         batch = dataset.take(chunk_ids)
         # Cast binary columns as earlier to avoid offset issues.
+        cast_start = time.time()
         columns = []
         fields = []
         for field in batch.schema:
@@ -349,22 +399,52 @@ def process_follow_up_round(
             columns.append(col)
             fields.append(pa.field(field.name, col.type))
         batch = pa.Table.from_arrays(columns, schema=pa.schema(fields))
+        record_timing("process_follow_up_round.cast", time.time() - cast_start, batch_id=shard)
 
+        prep_start = time.time()
         frames = [
             table_row_to_packet(batch, i, chunk_ids[i], default_video_id="lance_demo")
             for i in range(len(batch))
         ]
+        record_timing("process_follow_up_round.build_frames", time.time() - prep_start, batch_id=shard)
+        infer_start = time.time()
         outputs = run_features_on_frames(frames, {key: features[key] for key in round_cfg.feature_keys})
+        record_timing("process_follow_up_round.run_features", time.time() - infer_start, batch_id=shard)
+        convert_start = time.time()
         result_table = convert_results_to_table(chunk_ids, round_cfg.name, outputs)
+        record_timing("process_follow_up_round.convert", time.time() - convert_start, batch_id=shard)
+        write_start = time.time()
         write_batch_to_parquet(round_cfg.name, shard, result_table)
+        record_timing("process_follow_up_round.write", time.time() - write_start, batch_id=shard)
         shard += 1
         release_batch_memory(batch, frames, outputs, result_table)
+        record_timing("process_follow_up_round.batch", time.time() - batch_start, batch_id=shard - 1)
 
     if not found_any:
         print(f"No samples pending for round '{round_cfg.name}'.")
+    record_timing("process_follow_up_round.total", time.time() - round_start)
+
+
+def print_timing_summary() -> None:
+    if not TIMING_STATS:
+        print("No timing data collected.")
+        return
+
+    print("\nTiming summary:")
+    for name, values in TIMING_STATS.items():
+        if not values:
+            continue
+        total = sum(values)
+        avg = total / len(values)
+        max_val = max(values)
+        print(
+            f"  {name}: count={len(values)} total={total:.3f}s avg={avg:.3f}s max={max_val:.3f}s"
+        )
 
 
 def main() -> None:
+    global TIMING_STATS
+    TIMING_STATS = defaultdict(list)
     print("Loading Cortexia features...")
     caption = cortexia.create_feature("caption")
     listing = cortexia.create_feature("listing")
@@ -392,6 +472,7 @@ def main() -> None:
     process_follow_up_round(DATASET_PATH, round_one.name, round_two, features)
 
     print("Streaming inference complete. Results stored in:", OUTPUT_ROOT)
+    print_timing_summary()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the cookbook Lance example with a streaming pipeline that loads each batch lazily, wraps feature execution in torch.inference_mode, and releases GPU memory immediately
- convert batch outputs to a narrow Arrow schema and persist shards as partitioned Parquet files per processing round, ensuring results never accumulate in RAM
- add follow-up round processing that scans prior round shards for successful samples and rehydrates only the required rows for the next stage

## Testing
- python -m compileall cookbook/use_with_lance.py

------
https://chatgpt.com/codex/tasks/task_e_68d197293af08322b7e4caf5ee7c4d66